### PR TITLE
raising AttributeError when attribute not found

### DIFF
--- a/nefertari/utils/dictset.py
+++ b/nefertari/utils/dictset.py
@@ -27,6 +27,8 @@ class dictset(dict):
         return dictset([[k, v] for k, v in self.items() if k not in only])
 
     def __getattr__(self, key):
+        if key not in self:
+            raise AttributeError()
         return self[key]
 
     def __setattr__(self, key, val):


### PR DESCRIPTION
Quoted from Python documentation:

> This method should return the (computed) attribute value or raise an AttributeError exception.

https://docs.python.org/3/reference/datamodel.html#object.__getattr__
