### PR TITLE
Logging 404 at INFO level

### DIFF
--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 
 import elasticsearch
-from elasticsearch.exceptions import ConflictError, ElasticsearchException
+from elasticsearch.exceptions import ConflictError, ElasticsearchException, TransportError
 from elasticsearch import helpers
 import os
 import six
@@ -51,10 +51,10 @@ class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
                     msg = msg[:300] + '...TRUNCATED...' + msg[-212:]
                 log.debug(msg)
             resp = super(ESHttpConnection, self).perform_request(*args, **kw)
-        except Exception as e:
-            log.error(e.error)
+        except TransportError as e:
             status_code = e.status_code
             if status_code == 404 and 'IndexMissingException' in e.error:
+                log.error(str(e))
                 raise IndexNotFoundException()
             if status_code == 'N/A':
                 status_code = 400

--- a/nefertari/json_httpexceptions.py
+++ b/nefertari/json_httpexceptions.py
@@ -59,12 +59,14 @@ def create_json_response(obj, request=None, log_it=False, show_stack=False,
     show_stack = log_it or show_stack
     status = obj.status_int
 
-    if 400 <= status < 600 and status not in BLACKLIST_LOG or log_it:
+    if 400 <= status < 600 or log_it:
         msg = '%s: %s' % (obj.status.upper(), obj.body)
         if obj.status_int in [400, 500] or show_stack:
             msg += '\nSTACK TRACE BEGIN>>\n%s\nSTACK END<<' % add_stack(obj)
-
-        logger.error(msg)
+        if status in BLACKLIST_LOG:
+            logger.info(msg)
+        else:
+            logger.error(msg)
 
     obj.content_type = 'application/json'
     return obj


### PR DESCRIPTION
Currently, 404 errors get logged in `elasticsearch.perform_request` without any message.

This PR logs 404 errors like other 4xx and 5xx errors, but with logging level INFO instead of ERROR
