### PR TITLE
Update indexation

### DIFF
--- a/nefertari/__init__.py
+++ b/nefertari/__init__.py
@@ -49,11 +49,7 @@ def includeme(config):
     config.add_request_method(get_resource_map, 'resource_map', reify=True)
 
     config.add_tween('nefertari.tweens.cache_control')
-    try:
-        import pyramid_tm
-        config.add_tween('nefertari.tweens.es_tween', over='pyramid_tm.tm_tween_factory')
-    except ImportError:
-        pass
+    config.add_tween('nefertari.tweens.es_tween', over='pyramid_tm.tm_tween_factory')
 
     config.add_subscriber_predicate('model', ModelClassIs)
     config.add_subscriber_predicate('field', FieldIsChanged)

--- a/nefertari/__init__.py
+++ b/nefertari/__init__.py
@@ -49,7 +49,11 @@ def includeme(config):
     config.add_request_method(get_resource_map, 'resource_map', reify=True)
 
     config.add_tween('nefertari.tweens.cache_control')
-    config.add_tween('nefertari.tweens.es_tween_factory', over='pyramid_tm.tm_tween_factory')
+    try:
+        import pyramid_tm
+        config.add_tween('nefertari.tweens.es_tween', over='pyramid_tm.tm_tween_factory')
+    except ImportError:
+        pass
 
     config.add_subscriber_predicate('model', ModelClassIs)
     config.add_subscriber_predicate('field', FieldIsChanged)

--- a/nefertari/__init__.py
+++ b/nefertari/__init__.py
@@ -49,6 +49,7 @@ def includeme(config):
     config.add_request_method(get_resource_map, 'resource_map', reify=True)
 
     config.add_tween('nefertari.tweens.cache_control')
+    config.add_tween('nefertari.tweens.es_tween_factory', over='pyramid_tm.tm_tween_factory')
 
     config.add_subscriber_predicate('model', ModelClassIs)
     config.add_subscriber_predicate('field', FieldIsChanged)

--- a/nefertari/authentication/models.py
+++ b/nefertari/authentication/models.py
@@ -2,7 +2,7 @@ import uuid
 import logging
 
 import cryptacular.bcrypt
-from pyramid.security import authenticated_userid, forget
+from pyramid.security import forget
 
 from nefertari.json_httpexceptions import JHTTPBadRequest
 from nefertari import engine
@@ -131,7 +131,7 @@ class AuthModelMethodsMixin(object):
         Used by Ticket-based auth. Is added as request method to populate
         `request.user`.
         """
-        userid = authenticated_userid(request)
+        userid = request.authenticated_userid
         if userid:
             cache_request_user(cls, request, userid)
             return request._user
@@ -143,7 +143,7 @@ class AuthModelMethodsMixin(object):
         Used by Token-based auth. Is added as request method to populate
         `request.user`.
         """
-        username = authenticated_userid(request)
+        username = request.authenticated_userid
         if username:
             return cls.get_item(username=username)
 

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -644,7 +644,7 @@ class ES(object):
                 'Documents type must be `list`,`set` or `BaseDocument` not a `{}`'.format(
                     type(documents).__name__))
 
-    def index_document(self, document, request=None):
+    def index_document(self, document):
         if engine.is_object_document(document):
             """ Reindex all `document`s. """
             self._bulk('index', document.to_indexable_dict())
@@ -666,7 +666,7 @@ class ES(object):
         """ Reindex all `document`s. """
         self._bulk('index', dict_documents,)
 
-    def index_nested_document(self, parent, field, target, request=None):
+    def index_nested_document(self, parent, field, target):
         actions = []
         _doc_type = self.src2type(getattr(parent, '_type', self.doc_type))
         target_field = getattr(parent, field)
@@ -692,7 +692,7 @@ class ES(object):
 
         _bulk_body(actions)
 
-    def index_missing_documents(self, documents, request=None):
+    def index_missing_documents(self, documents):
         """ Index documents that are missing from ES index.
 
         Determines which documents are missing using ES `mget` call which
@@ -1072,7 +1072,7 @@ class ES(object):
         return dict2proxy(data, self.proxy)
 
     @classmethod
-    def index_relations(cls, db_obj, request=None, **kwargs):
+    def index_relations(cls, db_obj, **kwargs):
         for model_cls, documents in db_obj.get_related_documents(**kwargs):
             if getattr(model_cls, '_index_enabled', False) and documents:
                 children_to_index = []
@@ -1085,7 +1085,7 @@ class ES(object):
                 cls(model_cls.__name__).index_documents(children_to_index)
 
     @classmethod
-    def bulk_index_relations(cls, items, request=None, **kwargs):
+    def bulk_index_relations(cls, items, **kwargs):
         """ Index objects related to :items: in bulk.
         Related items are first grouped in map
         {model_name: {item1, item2, ...}} and then indexed.

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import json
 import threading
-from collections import OrderedDict
 import logging
 from functools import partial
 from collections import defaultdict
@@ -287,7 +286,7 @@ class ESActionRegistry(threading.local):
         """
         conflicts = []
         for error in exc.errors:
-            for action, response in error.items():
+            for response in error.values():
                 if response['status'] == 409:
                     log.error('CONFLICT DETECTED {response}'.format(response=response))
                     document = engine.reload_document(_type=response['_type'],_id=response['_id'])

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -344,7 +344,6 @@ class ESActionRegistry(threading.local):
             refresh_index = query_params.get('_refresh_index', refresh_index)
             refresh_parent = query_params.get('_refresh_parent', False)
         else:
-            refresh_index = True
             refresh_parent = False
 
         if refresh_parent:

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -70,7 +70,7 @@ class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
                 explanation=six.b(e.error),
                 extra=dict(data=e))
         else:
-            log.error('Unexpected ES ERROR ->{}'.format(e))
+            log.error('Unexpected ES ERROR ->{}'.format(resp))
             self._catch_index_error(resp)
             return resp
 

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -56,6 +56,7 @@ class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
                 log.debug(msg)
             resp = super(ESHttpConnection, self).perform_request(*args, **kw)
         except TransportError as e:
+            log.error('Elasticsearch ERROR ->{}'.format(e))
             status_code = e.status_code
             if status_code == 404 and 'IndexMissingException' in e.error:
                 log.error(str(e))

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -25,7 +25,7 @@ from nefertari.es_query import compile_es_query, apply_analyzer
 log = logging.getLogger(__name__)
 
 
-class IndexNotFoundException(Exception):
+class IndexNotFoundException(ElasticsearchException):
     pass
 
 

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -45,6 +45,7 @@ class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
             message = error_dict['error']
         except (KeyError, IndexError):
             return
+        log.error('Unexpected ES ERROR ->{}'.format(raw_data))
         raise exception_response(400, detail=message)
 
     def perform_request(self, *args, **kw):
@@ -70,7 +71,6 @@ class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
                 explanation=six.b(e.error),
                 extra=dict(data=e))
         else:
-            log.error('Unexpected ES ERROR ->{}'.format(resp))
             self._catch_index_error(resp)
             return resp
 

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -70,6 +70,7 @@ class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
                 explanation=six.b(e.error),
                 extra=dict(data=e))
         else:
+            log.error('Unexpected ES ERROR ->{}'.format(e))
             self._catch_index_error(resp)
             return resp
 

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -30,23 +30,23 @@ class IndexNotFoundException(ElasticsearchException):
 
 
 class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
-    # def _catch_index_error(self, response):
-    #     """ Catch and raise index errors which are not critical and thus
-    #     not raised by elasticsearch-py.
-    #     """
-    #     code, headers, raw_data = response
-    #     if not raw_data:
-    #         return
-    #     data = json.loads(raw_data)
-    #     if not data or not data.get('errors'):
-    #         return
-    #     try:
-    #         error_dict = data['items'][0]['index']
-    #         message = error_dict['error']
-    #     except (KeyError, IndexError):
-    #         return
-    #     log.error('Unexpected ES ERROR ->{}'.format(raw_data))
-    #     raise exception_response(400, detail=message)
+    def _catch_index_error(self, response):
+        """ Catch and raise index errors which are not critical and thus
+        not raised by elasticsearch-py.
+        """
+        code, headers, raw_data = response
+        if not raw_data:
+            return
+        data = json.loads(raw_data)
+        if not data or not data.get('errors'):
+            return
+        try:
+            error_dict = data['items'][0]['index']
+            message = error_dict['error']
+        except (KeyError, IndexError):
+            return
+        log.error('Unexpected ES ERROR ->{}'.format(raw_data))
+        raise exception_response(400, detail=message)
 
     def perform_request(self, *args, **kw):
         try:
@@ -74,7 +74,7 @@ class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
                 explanation=six.b(e.error),
                 extra=dict(data=e))
         else:
- #        self._catch_index_error(resp)
+            self._catch_index_error(resp)
             return resp
 
 

--- a/nefertari/elasticsearch.py
+++ b/nefertari/elasticsearch.py
@@ -46,7 +46,7 @@ class ESHttpConnection(elasticsearch.Urllib3HttpConnection):
         except (KeyError, IndexError):
             return
         log.error('Unexpected ES ERROR ->{}'.format(raw_data))
-        raise exception_response(503, detail=message)
+        raise exception_response(503, explanation=message)
 
     def perform_request(self, *args, **kw):
         try:

--- a/nefertari/json_httpexceptions.py
+++ b/nefertari/json_httpexceptions.py
@@ -92,6 +92,7 @@ thismodule = sys.modules[__name__]
 http_exceptions = list(http_exc.status_map.values()) + [
     http_exc.HTTPBadRequest,
     http_exc.HTTPInternalServerError,
+    http_exc.HTTPRequestTimeout
 ]
 
 for exc_cls in http_exceptions:

--- a/nefertari/json_httpexceptions.py
+++ b/nefertari/json_httpexceptions.py
@@ -89,11 +89,7 @@ class JBase(object):
 
 thismodule = sys.modules[__name__]
 
-http_exceptions = list(http_exc.status_map.values()) + [
-    http_exc.HTTPBadRequest,
-    http_exc.HTTPInternalServerError,
-    http_exc.HTTPRequestTimeout
-]
+http_exceptions = list(http_exc.status_map.values())
 
 for exc_cls in http_exceptions:
     name = "J%s" % exc_cls.__name__

--- a/nefertari/scripts/es.py
+++ b/nefertari/scripts/es.py
@@ -300,12 +300,9 @@ class TaskConsumer(Process):
         documents = to_indexable_dicts(query_set)
 
         es.index_missing_documents(documents)
-        es_actions = ESActionRegistry()
+        with ESActionRegistry() as es_registry:
+            es_registry.index()
 
-        for actions in es_actions.registry.values():
-            es_actions.force_indexation(actions=actions)
-
-        es_actions.registry.clear()
         return ids
 
 

--- a/nefertari/scripts/es.py
+++ b/nefertari/scripts/es.py
@@ -13,7 +13,7 @@ from sqlalchemy import text
 from six.moves import urllib
 
 from nefertari.utils import dictset, split_strip, to_dicts, to_indexable_dicts
-from nefertari.elasticsearch import ES, ESActionRegistry, create_index_with_settings
+from nefertari.elasticsearch import ES, create_index_with_settings
 from nefertari import engine
 
 
@@ -301,8 +301,9 @@ class TaskConsumer(Process):
         documents = to_indexable_dicts(query_set)
 
         es.index_missing_documents(documents)
-        with ESActionRegistry() as es_registry:
-            es_registry.index()
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
 
         return ids
 

--- a/nefertari/tweens.py
+++ b/nefertari/tweens.py
@@ -154,7 +154,7 @@ def enable_selfalias(config, id_name):
 def es_tween(handler, registry):
     """
     ES_tween called after pyramid_tm, so we can check if SQL transaction commited sucessfuly or with errors.
-    If response returned by handler:function will have status > 400 that means something went wrong and we should index any changes.
+    If response returned by handler:function will have status > 400 that means something went wrong and we should not index any changes.
     """
     log.info('ES tween enabled')
     from nefertari.elasticsearch import ES

--- a/nefertari/tweens.py
+++ b/nefertari/tweens.py
@@ -152,6 +152,10 @@ def enable_selfalias(config, id_name):
 
 
 def es_tween(handler, registry):
+    """
+    ES_tween called after pyramid_tm, so we can check if SQL transaction commited sucessfuly or with errors.
+    If response returned by handler:function will have status > 400 that means something went wrong and we should index any changes.
+    """
     log.info('ES tween enabled')
     from nefertari.elasticsearch import ES
 

--- a/nefertari/tweens.py
+++ b/nefertari/tweens.py
@@ -5,7 +5,6 @@ import json
 import six
 from pyramid.settings import asbool
 from nefertari.utils import drop_reserved_params
-from nefertari.elasticsearch import ESActionRegistry
 
 log = logging.getLogger(__name__)
 
@@ -152,14 +151,17 @@ def enable_selfalias(config, id_name):
     config.add_subscriber(context_found_subscriber, ContextFound)
 
 
-def es_tween_factory(handler, registry):
+def es_tween(handler, registry):
+    log.info('ES tween enabled')
+    from nefertari.elasticsearch import ES
+
     def es_tween(request):
-        with ESActionRegistry() as es_registry:
-            es_registry.bind(request)
+        with ES.registry:
+            ES.registry.bind(request)
             response = handler(request)
 
             if response.status_code < 300:
-                es_registry.index()
+                ES.registry.bulk_index()
 
         return response
     return es_tween

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     'zope.dottedname',
     'cryptacular',
     'six',
+    'pyramid_tm'
 ]
 
 setup(

--- a/tests/test_authentication/test_models.py
+++ b/tests/test_authentication/test_models.py
@@ -254,44 +254,39 @@ class TestAuthModelMethodsMixin(object):
         assert str(ex.value) == 'Failed to create account.'
         mock_get.assert_called_once_with(email=3, defaults={'email': 3})
 
-    @patch('nefertari.authentication.models.authenticated_userid')
     @patch('nefertari.authentication.models.cache_request_user')
     def test_get_authuser_by_userid(
-            self, mock_cache, mock_auth, engine_mock):
+            self, mock_cache, engine_mock):
         from nefertari.authentication import models
-        mock_auth.return_value = 123
         request = Mock()
+        request.authenticated_userid = 123
         models.AuthModelMethodsMixin.get_authuser_by_userid(request)
-        mock_auth.assert_called_once_with(request)
         mock_cache.assert_called_once_with(
             models.AuthModelMethodsMixin, request, 123)
 
-    @patch('nefertari.authentication.models.authenticated_userid')
     @patch('nefertari.authentication.models.cache_request_user')
     def test_get_authuser_by_userid_not_authenticated(
-            self, mock_cache, mock_auth, engine_mock):
+            self, mock_cache, engine_mock):
         from nefertari.authentication import models
-        mock_auth.return_value = None
-        models.AuthModelMethodsMixin.get_authuser_by_userid(1)
-        mock_auth.assert_called_once_with(1)
+        request = Mock()
+        request.authenticated_userid = None
+        models.AuthModelMethodsMixin.get_authuser_by_userid(request)
         assert not mock_cache.called
 
-    @patch('nefertari.authentication.models.authenticated_userid')
     @patch(mixin_path + 'get_item')
     def test_get_authuser_by_name(
-            self, mock_res, mock_auth, engine_mock):
+            self, mock_res,  engine_mock):
         from nefertari.authentication import models
-        mock_auth.return_value = 'user1'
-        models.AuthModelMethodsMixin.get_authuser_by_name(1)
-        mock_auth.assert_called_once_with(1)
+        request = Mock()
+        request.authenticated_userid = 'user1'
+        models.AuthModelMethodsMixin.get_authuser_by_name(request)
         mock_res.assert_called_once_with(username='user1')
 
-    @patch('nefertari.authentication.models.authenticated_userid')
     @patch(mixin_path + 'get_item')
     def test_get_authuser_by_name_not_authenticated(
-            self, mock_res, mock_auth, engine_mock):
+            self, mock_res, engine_mock):
         from nefertari.authentication import models
-        mock_auth.return_value = None
-        models.AuthModelMethodsMixin.get_authuser_by_name(1)
-        mock_auth.assert_called_once_with(1)
+        request = Mock()
+        request.authenticated_userid = None
+        models.AuthModelMethodsMixin.get_authuser_by_name(request)
         assert not mock_res.called

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,12 +1,14 @@
 import logging
+from datetime import datetime, timedelta
 
 import six
 import pytest
 from mock import Mock, patch, call
 from elasticsearch.exceptions import TransportError
 from nefertari import elasticsearch as es
-from nefertari.json_httpexceptions import JHTTPBadRequest, JHTTPNotFound, JHTTPUnprocessableEntity
+from nefertari.json_httpexceptions import JHTTPBadRequest, JHTTPNotFound, JHTTPUnprocessableEntity, JHTTPRequestTimeout
 from nefertari.utils import dictset
+from nefertari.elasticsearch import ES, ESData
 
 
 class MockEngine(Mock):
@@ -14,6 +16,60 @@ class MockEngine(Mock):
         mock_document = Mock()
         mock_document.get_es_mapping = lambda: ({name: {'properties': {}}}, None)
         return mock_document
+
+
+class TestESActionRegistry(object):
+
+    def test_get_latest_change(self):
+        now = datetime.now()
+        in_two_hours = now + timedelta(hours=2)
+        first_data = ESData(action={'_op_type': 'index', '_type': 'Item','_id': 2}, created_at=now)
+        second_data = ESData(action={'_op_type': 'index', '_type': 'Item','_id': 2}, created_at=in_two_hours)
+        gen = ES.registry.get_latest_change([first_data, second_data])
+        result = next(gen)
+
+        assert result == second_data
+
+        with pytest.raises(StopIteration):
+            next(gen)
+
+    def test_filter_deleted_items_from_index(self):
+        now = datetime.now()
+        in_two_hours = now + timedelta(hours=2)
+        first_data = ESData(action={'_op_type': 'index', '_type': 'Item','_id': 2}, created_at=now)
+        second_data = ESData(action={'_op_type': 'delete', '_type': 'Item','_id': 2}, created_at=in_two_hours)
+        result = ES.registry.prepare_for_deletion([first_data, second_data])
+
+        assert len(result) == 1
+        assert result[0] == second_data
+
+    def test_filter_deleted_items_from_index_without_deleted(self):
+        now = datetime.now()
+        in_two_hours = now + timedelta(hours=2)
+        first_data = ESData(action={'_op_type': 'index', '_type': 'Item','_id': 2}, created_at=now)
+        second_data = ESData(action={'_op_type': 'index', '_type': 'Item','_id': 2}, created_at=in_two_hours)
+        result = ES.registry.prepare_for_deletion([first_data, second_data])
+
+        assert len(result) == 2
+        expected = [first_data, second_data]
+
+        for item in result:
+            assert item in expected
+            expected.remove(item)
+
+    def test_filter_deleted_items_from_index_without_index(self):
+        now = datetime.now()
+        in_two_hours = now + timedelta(hours=2)
+        first_data = ESData(action={'_op_type': 'deleted', '_type': 'Item','_id': 1}, created_at=now)
+        second_data = ESData(action={'_op_type': 'deleted', '_type': 'Item','_id': 2}, created_at=in_two_hours)
+        result = ES.registry.prepare_for_deletion([first_data, second_data])
+
+        assert len(result) == 2
+        expected = [first_data, second_data]
+
+        for item in result:
+            assert item in expected
+            expected.remove(item)
 
 
 class TestESHttpConnection(object):
@@ -73,7 +129,16 @@ class TestESHttpConnection(object):
         conn = es.ESHttpConnection()
         conn.pool = Mock()
         conn.pool.urlopen.side_effect = TransportError('N/A', '')
+        print('here')
         with pytest.raises(JHTTPBadRequest):
+            conn.perform_request('POST', 'http://localhost:9200')
+
+    def test_request_timeout_exception(self):
+        from urllib3.exceptions import ReadTimeoutError
+        conn = es.ESHttpConnection()
+        conn.pool = Mock()
+        conn.pool.urlopen.side_effect = ReadTimeoutError(Mock(), Mock(), Mock())
+        with pytest.raises(JHTTPRequestTimeout):
             conn.perform_request('POST', 'http://localhost:9200')
 
     @patch('nefertari.elasticsearch.log')
@@ -129,52 +194,57 @@ class TestHelperFunctions(object):
         assert docs._total == 0
         assert docs._start == 0
 
-    @patch('nefertari.elasticsearch.ES')
+    @patch('nefertari.elasticsearch.ES.settings')
     @patch('nefertari.elasticsearch.helpers')
-    def test_bulk_body(self, mock_helpers, mock_es):
+    def test_bulk_body(self, mock_helpers, mock_settings):
         mock_helpers.bulk.return_value = (1, [])
         request = Mock()
         request.params.mixed.return_value = {'_refresh_index': True}
-        es._bulk_body('foo', request)
-        import transaction
-        transaction.commit()
-        mock_helpers.bulk.assert_called_once_with(
-            client=mock_es.api, refresh=True, actions='foo')
+        with ES.registry as es_registry:
+            es._bulk_body([{'_op_type': 'index', '_type': 'Item','_id': 2}])
+            es_registry.bulk_index()
+            mock_helpers.bulk.assert_called_once_with(
+                client=ES.api, refresh=True, actions=[{'_op_type': 'index', '_type': 'Item','_id':2}])
 
-    @patch('nefertari.elasticsearch.ES')
+    @patch('nefertari.elasticsearch.ES.settings')
     @patch('nefertari.elasticsearch.helpers')
-    def test_bulk_body_missed_refresh_index(self, mock_helpers, mock_es):
+    def test_bulk_body_missed_refresh_index(self, mock_helpers, mock_settings):
         mock_helpers.bulk.return_value = (1, [])
         request = Mock()
         request.params.mixed.return_value = dict()
-        es._bulk_body('foo', request)
-        import transaction
-        transaction.commit()
-        mock_helpers.bulk.assert_called_once_with(
-            client=mock_es.api, refresh=True, actions='foo')
+        with ES.registry as es_registry:
+            es_registry.bind(request)
+            es._bulk_body([{'_op_type': 'index', '_type': 'Item','_id': 2}])
+            es_registry.bulk_index()
+            mock_helpers.bulk.assert_called_once_with(
+                client=ES.api, refresh=True, actions=[{'_op_type': 'index', '_type': 'Item','_id': 2}])
 
-    @patch('nefertari.elasticsearch.ES')
+    @patch('nefertari.elasticsearch.ES.settings')
     @patch('nefertari.elasticsearch.helpers')
-    def test_bulk_body_refresh_index_false(self, mock_helpers, mock_es):
+    def test_bulk_body_refresh_index_false(self, mock_helpers, mock_settings):
         mock_helpers.bulk.return_value = (1, [])
         request = Mock()
         request.params.mixed.return_value = {'_refresh_index': False}
-        es._bulk_body('foo', request)
-        import transaction
-        transaction.commit()
-        mock_helpers.bulk.assert_called_once_with(
-            client=mock_es.api, refresh=False, actions='foo')
 
-    @patch('nefertari.elasticsearch.ES')
+        with ES.registry as es_registry:
+            es_registry.bind(request)
+            es._bulk_body([{'_op_type': 'index', '_type': 'Item','_id': 2}])
+            es_registry.bulk_index()
+            mock_helpers.bulk.assert_called_once_with(
+                client=ES.api, refresh=False, actions=[{'_op_type': 'index', '_type': 'Item','_id': 2}])
+
+    @patch('nefertari.elasticsearch.ES.settings')
     @patch('nefertari.elasticsearch.helpers')
-    def test_bulk_body_transaction_failed(self, mock_helpers, mock_es):
+    def test_indexation_failed(self, mock_helpers, mock_settings):
         mock_helpers.bulk.return_value = (1, [])
         request = Mock()
         request.params.mixed.return_value = {'_refresh_index': True}
-        es._bulk_body('foo', request)
-        import transaction
-        transaction.abort()
-        mock_helpers.bulk.assert_not_called()
+        es._bulk_body([{'_op_type': 'index', '_type': 'Item','_id': 2}])
+
+        with pytest.raises(Exception):
+            with ES.registry:
+                raise Exception()
+            assert len(ES.registry.registry) == 0
 
 
 class TestES(object):
@@ -199,6 +269,7 @@ class TestES(object):
         settings = dictset({
             'elasticsearch.hosts': '127.0.0.1:8080,127.0.0.2:8090',
             'elasticsearch.sniff': 'true',
+            'elasticsearch.retry_on_timeout': 'true'
         })
         es.ES.setup(settings)
         mock_es.Elasticsearch.assert_called_once_with(
@@ -207,7 +278,8 @@ class TestES(object):
             serializer=mock_engine.ESJSONSerializer(),
             connection_class=es.ESHttpConnection,
             sniff_on_start=True,
-            sniff_on_connection_fail=True
+            sniff_on_connection_fail=True,
+            retry_on_timeout=True
         )
         assert es.ES.api == mock_es.Elasticsearch()
 
@@ -328,7 +400,7 @@ class TestES(object):
         obj._bulk('index', docs)
         mock_prep.assert_called_once_with('index', docs)
         mock_part.assert_called_once_with(
-            es._bulk_body, request=None)
+            es._bulk_body)
         mock_proc.assert_called_once_with(
             documents=[{
                 '_id': 'story1', '_op_type': 'index',
@@ -357,19 +429,19 @@ class TestES(object):
         obj = es.ES('Foo', 'foondex', chunk_size=4)
 
         # Indexing a list
-        obj.index(['a'], request={"test": "test"})
-        mock_index_documents.assert_called_once_with(['a'], request={"test": "test"})
+        obj.index(['a'])
+        mock_index_documents.assert_called_once_with(['a'])
 
         # Indexing a set
-        obj.index({'a'}, request={"test": "test"})
-        mock_index_documents.assert_called_with(['a'], request={"test": "test"})
+        obj.index({'a'})
+        mock_index_documents.assert_called_with(['a'])
         mock_engine.is_object_document = Mock(return_value=True)
 
         # Indexing a document
         fake_document = Mock()
         fake_document.to_indexable_dict = Mock(return_value={"a": "b"})
-        obj.index(fake_document, request=None)
-        mock_bulk.assert_called_once_with("index", {"a": "b"}, None)
+        obj.index(fake_document)
+        mock_bulk.assert_called_once_with("index", {'a': 'b'})
 
     @patch('nefertari.elasticsearch.engine')
     @patch('nefertari.elasticsearch.ES._bulk')
@@ -379,8 +451,8 @@ class TestES(object):
         fake_document = Mock()
         fake_document.to_indexable_dict = Mock(return_value={"a": "b"})
         mock_engine.is_object_document = Mock(return_value=True)
-        obj.index_document(fake_document, request=None)
-        mock_bulk.assert_called_once_with("index", {"a": "b"}, None)
+        obj.index_document(fake_document)
+        mock_bulk.assert_called_once_with("index", {"a": "b"})
 
         mock_engine.is_object_document = Mock(return_value=False)
 
@@ -396,61 +468,531 @@ class TestES(object):
         fake_document.to_indexable_dict = Mock(return_value={"a": "b"})
         mock_engine.is_object_document = Mock(return_value=True)
 
-        obj.index_documents([fake_document, fake_document], request=None)
-        mock_bulk.assert_called_once_with("index", [{"a": "b"}, {"a": "b"}], None)
+        obj.index_documents([fake_document, fake_document])
+        mock_bulk.assert_called_once_with("index", [{"a": "b"}, {"a": "b"}])
 
         mock_engine.is_object_document = Mock(return_value=False)
 
         with pytest.raises(TypeError):
             obj.index_documents([fake_document, fake_document])
 
-    @patch('nefertari.elasticsearch.ES._bulk')
-    def test_delete(self, mock_bulk):
-        obj = es.ES('Foo', 'foondex')
-        obj.delete(ids=[1, 2])
-        mock_bulk.assert_called_once_with(
-            'delete', [{'_pk': 1, '_type': 'Foo'},
-                       {'_pk': 2, '_type': 'Foo'}],
-            request=None)
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_delete(self, mock_bulk, mock_settings):
+        obj = es.ES('Foo', 'foondex', chunk_size=4)
+        obj.delete(ids=[1])
 
-    @patch('nefertari.elasticsearch.ES._bulk')
-    def test_delete_single_obj(self, mock_bulk):
-        obj = es.ES('Foo', 'foondex')
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        mock_bulk.assert_called_once_with(actions=[{'_op_type': 'delete', '_id': 1, '_index': 'foondex', '_type': 'Foo'}],
+                                          client=ES.api, refresh=True)
+
+
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_delete_single_obj(self, mock_bulk, mock_settings):
+        obj = es.ES('Foo', 'foondex', chunk_size=4)
         obj.delete(ids=1)
-        mock_bulk.assert_called_once_with(
-            'delete', [{'_pk': 1, '_type': 'Foo'}],
-            request=None)
 
-    @patch('nefertari.elasticsearch.ES._bulk')
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        mock_bulk.assert_called_once_with(
+            actions=[{'_op_type': 'delete', '_id': 1, '_index': 'foondex', '_type': 'Foo'}],
+            client=ES.api, refresh=True)
+
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
     @patch('nefertari.elasticsearch.ES.api.mget')
-    def test_index_missing_documents(self, mock_mget, mock_bulk):
-        obj = es.ES('Foo', 'foondex')
+    @patch('nefertari.elasticsearch.ES.api')
+    def test_index_missing_documents(self,mock_api, mock_mget, mock_bulk, mock_settings):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
         documents = [
             {'_pk': 1, 'name': 'foo'},
-            {'_pk': 2, 'name': 'bar'},
-            {'_pk': 3, 'name': 'baz'},
+            {'_pk': 2, 'name': 'bar'}
         ]
         mock_mget.return_value = {'docs': [
             {'_id': '1', 'name': 'foo', 'found': False},
-            {'_id': '2', 'name': 'bar', 'found': True},
-            {'_id': '3', 'name': 'baz'},
+            {'_id': '2', 'name': 'bar', 'found': True}
         ]}
+
         obj.index_missing_documents(documents)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
         mock_mget.assert_called_once_with(
             index='foondex',
             doc_type='Foo',
             fields=['_id'],
-            body={'ids': [1, 2, 3]}
+            body={'ids': [1, 2]}
         )
-        mock_bulk.assert_called_once_with(
-            'index', [
-                {'_pk': 1, 'name': 'foo'}, {'_pk': 3, 'name': 'baz'}
-            ], None)
+        mock_bulk.assert_called_once_with(actions=[
+            {'_id': 1, '_type': 'Foo', '_source': {'_pk': 1, 'name': 'foo'}, '_op_type': 'index', '_index': 'foondex'}
+        ], client=mock_api, refresh=True)
 
-    @patch('nefertari.elasticsearch.ES._bulk')
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+        documents = [
+            first_document,
+            second_document
+        ]
+
+        obj.index(documents)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        mock_bulk.assert_called_once_with(actions=[
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Doc', '_index': 'foondex'}
+        ], client=mock_api, refresh=True)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice_different_type(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Item'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+        documents = [
+            first_document,
+            second_document
+        ]
+
+        obj.index(documents)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Doc', '_index': 'foondex'},
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Item', '_index': 'foondex'}
+        ]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice_multiple_index_different_type(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Item'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+
+
+        obj.index(first_document)
+        obj.index(second_document)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Doc', '_index': 'foondex'},
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Item', '_index': 'foondex'}
+        ]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice_multiple_index(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+
+        obj.index(first_document)
+        obj.index(second_document)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        mock_bulk.assert_called_once_with(actions=[
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Doc', '_index': 'foondex'}
+        ], client=mock_api, refresh=True)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice_differnt_pk(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 2, 'name': 'foo', '_type': 'Doc'})
+
+
+        obj.index(first_document)
+        obj.index(second_document)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Doc', '_index': 'foondex'},
+            {'_source': {'name': 'foo', '_pk': 2}, '_op_type': 'index', '_id': 2, '_type': 'Doc', '_index': 'foondex'}
+        ]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice_differnt_pk_different_type(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Item'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 2, 'name': 'foo', '_type': 'Doc'})
+
+
+        obj.index(first_document)
+        obj.index(second_document)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Item', '_index': 'foondex'},
+            {'_source': {'name': 'foo', '_pk': 2}, '_op_type': 'index', '_id': 2, '_type': 'Doc', '_index': 'foondex'}
+        ]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice_differnt_pk_different_type(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Item'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 2, 'name': 'foo', '_type': 'Doc'})
+
+
+        obj.index(first_document)
+        obj.index(second_document)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_source': {'name': 'foo', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Item', '_index': 'foondex'},
+            {'_source': {'name': 'foo', '_pk': 2}, '_op_type': 'index', '_id': 2, '_type': 'Doc', '_index': 'foondex'}
+        ]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice_with_changes_in_second_update(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'bar', '_type': 'Doc'})
+
+        obj.index(first_document)
+        obj.index(second_document)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_source': {'name': 'bar', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Doc', '_index': 'foondex'}]
+
+        assert 'actions' in args
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_three_times(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'bar', '_type': 'Doc'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+        third_document = Mock()
+        third_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'bar', '_type': 'Doc'})
+
+        obj.index(first_document)
+        obj.index(second_document)
+        obj.index(third_document)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_source': {'name': 'bar', '_pk': 1}, '_op_type': 'index', '_id': 1, '_type': 'Doc', '_index': 'foondex'}]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_single_document_twice_and_delete_it(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        obj = es.ES('Doc', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'bar', '_type': 'Doc'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+
+        obj.index(first_document)
+        obj.index(second_document)
+        obj.delete([1])
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_id': 1, '_type': 'Doc', '_index': 'foondex', '_op_type': 'delete'}
+        ]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_twice_delete_document(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        obj = es.ES('Doc', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        obj.delete([1])
+        obj.delete([1])
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_id': 1, '_type': 'Doc', '_index': 'foondex', '_op_type': 'delete'}
+        ]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_index_after_delete(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        obj = es.ES('Doc', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'bar', '_type': 'Doc'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
+
+        obj.delete([1])
+
+        obj.index(first_document)
+        obj.index(second_document)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_id': 1, '_type': 'Doc', '_index': 'foondex', '_op_type': 'delete'}
+        ]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.engine')
+    @patch('nefertari.elasticsearch.ES.api')
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_different_actions_in_one_request(self, mock_bulk, mock_settings, mock_api, mock_engine):
+        obj = es.ES('Doc', 'foondex', chunk_size=10)
+        mock_engine.is_object_document = Mock(return_value=True)
+
+        first_document = Mock()
+        first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'bar', '_type': 'Doc'})
+        second_document = Mock()
+        second_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'changed', '_type': 'Doc'})
+        third_document = Mock()
+        third_document.to_indexable_dict = Mock(return_value={'_pk': 2, 'name': 'foo', '_type': 'Doc'})
+        fourth_document = Mock()
+        fourth_document.to_indexable_dict = Mock(return_value={'_pk': 3, 'name': 'foo', '_type': 'Doc'})
+
+        obj.delete([3])
+        obj.index(first_document)
+        obj.index(second_document)
+        obj.index([third_document, fourth_document])
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        args = mock_bulk._mock_call_args[1]
+        result_actions = [
+            {'_type': 'Doc', '_index': 'foondex', '_op_type': 'delete', '_id': 3},
+            {'_type': 'Doc', '_source': {'name': 'foo', '_pk': 2}, '_index': 'foondex', '_op_type': 'index', '_id': 2},
+            {'_type': 'Doc', '_source': {'name': 'changed', '_pk': 1}, '_index': 'foondex', '_op_type': 'index', '_id': 1}]
+
+        assert 'actions' in args
+
+        for action in args['actions']:
+            assert action in result_actions
+            result_actions.remove(action)
+
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    def test_exit_with_exception_from_registry_will_clean_it(self, mock_bulk, mock_settings):
+        obj = es.ES('Foo', 'foondex', chunk_size=4)
+        obj.delete(ids=[1])
+        request = Mock()
+
+        try:
+            with ES.registry as es_registry:
+                es_registry.bind(request)
+                raise Exception()
+        except:
+            pass
+
+        es_registry = ES.registry
+        print(es_registry.registry)
+        assert not mock_bulk.called
+        assert len(es_registry.registry) == 0
+        assert es_registry.request is None
+
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
     @patch('nefertari.elasticsearch.ES.api.mget')
-    def test_index_missing_documents_no_index(self, mock_mget, mock_bulk):
-        obj = es.ES('Foo', 'foondex')
+    @patch('nefertari.elasticsearch.ES.api')
+    def test_index_missing_documents_document_not_exist(self,mock_api, mock_mget, mock_bulk, mock_settings):
+        print('here')
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
+        documents = [
+            {'_pk': 1, 'name': 'foo'},
+            {'_pk': 2, 'name': 'bar'}
+        ]
+        mock_mget.return_value = {'docs': [
+            {'_id': '2', 'name': 'bar', 'found': True}
+        ]}
+
+        obj.index_missing_documents(documents)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        mock_mget.assert_called_once_with(
+            index='foondex',
+            doc_type='Foo',
+            fields=['_id'],
+            body={'ids': [1, 2]}
+        )
+        mock_bulk.assert_called_once_with(actions=[
+            {'_id': 1, '_type': 'Foo', '_source': {'_pk': 1, 'name': 'foo'}, '_op_type': 'index', '_index': 'foondex'}
+        ], client=mock_api, refresh=True)
+
+
+
+    @patch('nefertari.elasticsearch.ES.settings')
+    @patch('nefertari.elasticsearch.helpers.bulk')
+    @patch('nefertari.elasticsearch.ES.api.mget')
+    @patch('nefertari.elasticsearch.ES.api')
+    def test_index_missing_documents_no_index(self, mock_api, mock_mget, mock_bulk, mock_settings):
+        obj = es.ES('Foo', 'foondex', chunk_size=10)
         documents = [
             {'_pk': 1, 'name': 'foo'},
         ]
@@ -462,8 +1004,14 @@ class TestES(object):
             fields=['_id'],
             body={'ids': [1]}
         )
-        mock_bulk.assert_called_once_with(
-            'index', [{'_pk': 1, 'name': 'foo'}], None)
+
+        with ES.registry as es_registry:
+            es_registry.bulk_index()
+
+        mock_bulk.assert_called_once_with(actions=[{'_op_type': 'index', '_type': 'Foo', '_index': 'foondex', '_source': {'name': 'foo', '_pk': 1}, '_id': 1}],
+                                          client=mock_api, refresh=True)
+
+
 
     @patch('nefertari.elasticsearch.ES._bulk')
     @patch('nefertari.elasticsearch.ES.api.mget')
@@ -974,7 +1522,7 @@ class TestES(object):
         db_obj.get_related_documents.return_value = [(Foo, docs)]
         mock_settings.index_name = 'foo'
         es.ES.index_relations(db_obj)
-        mock_ind.assert_called_once_with(docs, request=None)
+        mock_ind.assert_called_once_with(docs)
 
     @patch('nefertari.elasticsearch.ES.settings')
     @patch('nefertari.elasticsearch.ES.index')
@@ -1008,7 +1556,7 @@ class TestES(object):
             (Foo, [doc2])]
 
         es.ES.bulk_index_relations([db_object1, db_object2])
-        mock_index.assert_called_once_with({doc1, doc2}, request=None)
+        mock_index.assert_called_once_with({doc1, doc2})
 
     def test_document_proxies_inheritance(self):
         es.ES.document_proxy.update_document_proxies('Foo', 'BlaBla')

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -77,6 +77,7 @@ class TestESActionRegistry(object):
     @patch('nefertari.elasticsearch.helpers.bulk')
     def test_reindex_conflicts(self, mock_bulk, mock_settings, mock_api, mock_engine):
         exc = Mock()
+        mock_settings.asbool.return_value = True
         exc.errors = [{'index': {'status': 409, '_type': 'Doc', '_id': 1, '_index': 'foondex'}}]
         mock_engine.reload_document = lambda *args, **kwargs: {'_pk': 1, 'name': 'foo', '_type': 'Doc'}
         ES.registry.reindex_conflicts(exc)
@@ -106,6 +107,7 @@ class TestESActionRegistry(object):
         exc = Mock()
         exc.errors = [{'update': {'status': 409, '_type': 'Doc', '_id': 1, '_index': 'foondex'}}]
         mock_engine.reload_document = lambda *args, **kwargs: {'_pk': 1, 'name': 'foo', '_type': 'Doc'}
+        mock_settings.asbool.return_value = True
         ES.registry.reindex_conflicts(exc)
         ES.registry.clean()
 
@@ -241,6 +243,7 @@ class TestHelperFunctions(object):
         mock_helpers.bulk.return_value = (1, [])
         request = Mock()
         request.params.mixed.return_value = {'_refresh_index': True}
+        mock_settings.asbool.return_value = True
         with ES.registry as es_registry:
             es._bulk_body([{'_op_type': 'index', '_type': 'Item','_id': 2}])
             es_registry.bulk_index()
@@ -267,6 +270,7 @@ class TestHelperFunctions(object):
         mock_helpers.bulk.return_value = (1, [])
         request = Mock()
         request.params.mixed.return_value = {'_refresh_index': False}
+        mock_settings.asbool.return_value = True
 
         with ES.registry as es_registry:
             es_registry.bind(request)
@@ -280,6 +284,7 @@ class TestHelperFunctions(object):
     def test_indexation_failed(self, mock_helpers, mock_settings):
         mock_helpers.bulk.return_value = (1, [])
         request = Mock()
+        mock_settings.asbool.return_value = True
         request.params.mixed.return_value = {'_refresh_index': True}
         es._bulk_body([{'_op_type': 'index', '_type': 'Item','_id': 2}])
 
@@ -608,6 +613,7 @@ class TestES(object):
     def test_delete(self, mock_bulk, mock_settings):
         obj = es.ES('Foo', 'foondex', chunk_size=4)
         obj.delete(ids=[1])
+        mock_settings.asbool.return_value = True
 
         with ES.registry as es_registry:
             es_registry.bulk_index()
@@ -621,6 +627,7 @@ class TestES(object):
     def test_delete_single_obj(self, mock_bulk, mock_settings):
         obj = es.ES('Foo', 'foondex', chunk_size=4)
         obj.delete(ids=1)
+        mock_settings.asbool.return_value = True
 
         with ES.registry as es_registry:
             es_registry.bulk_index()
@@ -636,6 +643,7 @@ class TestES(object):
     def test_index_missing_documents(self,mock_api, mock_mget, mock_bulk, mock_settings):
         print('here')
         obj = es.ES('Foo', 'foondex', chunk_size=10)
+        mock_settings.asbool.return_value = True
         documents = [
             {'_pk': 1, 'name': 'foo'},
             {'_pk': 2, 'name': 'bar'}
@@ -667,6 +675,7 @@ class TestES(object):
     def test_index_single_document_twice(self, mock_bulk, mock_settings, mock_api, mock_engine):
         obj = es.ES('Foo', 'foondex', chunk_size=10)
         mock_engine.is_object_document = Mock(return_value=True)
+        mock_settings.asbool.return_value = True
 
         first_document = Mock()
         first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
@@ -693,6 +702,7 @@ class TestES(object):
     def test_index_single_document_twice_different_type(self, mock_bulk, mock_settings, mock_api, mock_engine):
         obj = es.ES('Foo', 'foondex', chunk_size=10)
         mock_engine.is_object_document = Mock(return_value=True)
+        mock_settings.asbool.return_value = True
 
         first_document = Mock()
         first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Item'})
@@ -726,6 +736,7 @@ class TestES(object):
     def test_index_single_document_twice_multiple_index_different_type(self, mock_bulk, mock_settings, mock_api, mock_engine):
         obj = es.ES('Foo', 'foondex', chunk_size=10)
         mock_engine.is_object_document = Mock(return_value=True)
+        mock_settings.asbool.return_value = True
 
         first_document = Mock()
         first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Item'})
@@ -757,6 +768,7 @@ class TestES(object):
     def test_index_single_document_twice_multiple_index(self, mock_bulk, mock_settings, mock_api, mock_engine):
         obj = es.ES('Foo', 'foondex', chunk_size=10)
         mock_engine.is_object_document = Mock(return_value=True)
+        mock_settings.asbool.return_value = True
 
         first_document = Mock()
         first_document.to_indexable_dict = Mock(return_value={'_pk': 1, 'name': 'foo', '_type': 'Doc'})
@@ -1087,6 +1099,7 @@ class TestES(object):
         mock_mget.return_value = {'docs': [
             {'_id': '2', 'name': 'bar', 'found': True}
         ]}
+        mock_settings.asbool.return_value = True
 
         obj.index_missing_documents(documents)
 
@@ -1115,6 +1128,7 @@ class TestES(object):
             {'_pk': 1, 'name': 'foo'},
         ]
         mock_mget.side_effect = es.IndexNotFoundException()
+        mock_settings.asbool.return_value = True
         obj.index_missing_documents(documents)
         mock_mget.assert_called_once_with(
             index='foondex',

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -47,6 +47,7 @@ def get_test_view_class(name=''):
 
 def _create_config():
     config = Configurator(autocommit=True)
+    config.include('pyramid_tm')
     config.include('nefertari')
     return config
 


### PR DESCRIPTION
This PR contains changes related to these stories
https://www.pivotaltracker.com/story/show/145909689
https://www.pivotaltracker.com/story/show/142078823

Added new param `_refresh_parent`. If client will add this param to `POST/PATCH` query for single entity nefertari will reload parent document from database. This feature will solve issue with concurrent create, when nested entities wasn't properly indexed in parent document.

https://github.com/geniusproject/cerri-api/wiki/How-to:-Concurrent-create-update